### PR TITLE
Fix compiling error regarding angular fire, CDK and material deps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "~10.0.11",
-    "@angular/cdk": "~10.1.3",
+    "@angular/cdk": "^10.1.3",
     "@angular/common": "~10.0.11",
     "@angular/compiler": "~10.0.11",
     "@angular/core": "~10.0.11",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
+    "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "declaration": false,
     "downlevelIteration": true,


### PR DESCRIPTION
I was having some issues with compiling the app. 
- The current version of @angular/fire uses CommonJS and Typescript warns you about it.
- @angular/cdk and @angular/material can have unsynchronized dependency versions.

I used the node version specified by the .nvmrc